### PR TITLE
Fix guild being null when creating channels

### DIFF
--- a/src/client/rest/structures/Channel.ts
+++ b/src/client/rest/structures/Channel.ts
@@ -16,19 +16,18 @@ export class Channel {
 	public parentId: string;
 	public guild: Guild;
 	public nsfw: boolean;
-	constructor(client: BaseClient, data: ChannelData) {
+	constructor(client: BaseClient, data: ChannelData, guild?: Guild) {
 		this.client = client;
 		this.id = data.id;
 		this.type = data.type;
-		this.guildId = data.guild_id;
+		this.guildId = guild ? guild.id : data.guild_id;
 		this.position = data.position;
 		this.permissionOverwrites = data.permission_overwrites;
 		this.name = data.name;
 		this.topic = data.topic;
 		this.parentId = data.parent;
 		this.nsfw = data.nsfw;
-		console.log(this.guildId);
-		this.guild = this.client.guilds.get(this.guildId);
+		this.guild = guild ? guild : this.client.guilds.get(data.guild_id);
 	}
 
 	public async send(data: MessageCreateData): Promise<Message> {

--- a/src/client/rest/structures/Guild.ts
+++ b/src/client/rest/structures/Guild.ts
@@ -13,7 +13,7 @@ export class Guild {
 
 		if (client.options.cache.channels) {
 			for (const rawChannel of data.channels.values()) {
-				const channel = new Channel(client, rawChannel);
+				const channel = new Channel(client, rawChannel, this);
 				this.channels.set(channel.id, channel);
 			}
 		}


### PR DESCRIPTION
Unfortunately the channels that are included with the GUILD_CREATE packet do not contain a guild ID property since the Discord developers would assume you would INFER IT FROM THE ACTUAL PACKET ITSELF.